### PR TITLE
adding ability to execute entire cql library and return the results

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ export function initializeCqlWorker(cqlWorker, isNodeJs=false) {
     // If the response is that cqlWorker is still waiting on the patient bundle, 
     // wait 100 ms and resend.
     if (result == 'WAITING_FOR_PATIENT_BUNDLE') {
-      setTimeout( () => cqlWorker.postMessage({expression: expression}), 100);
+      setTimeout( () => cqlWorker.postMessage({__evaluate_library__: 'true'}), 100);
     } else {
       // Try to find this expression in the messageArray
       let executingExpressionIndex = messageArray.map((msg,idx) => {
@@ -100,10 +100,19 @@ export function initializeCqlWorker(cqlWorker, isNodeJs=false) {
     }
   };
 
+  /**
+   * Sends a command to the webworker for to evaluate the entire library.
+   * @returns {boolean} - A dummy return value.
+   */
+  const evaluateLibrary = async function() {
+    return evaluateExpression('__evaluate_library__');
+  };
+
   return [
     setupExecution,
     sendPatientBundle,
-    evaluateExpression
+    evaluateExpression,
+    evaluateLibrary
   ];
 }
 

--- a/src/CqlProcessor.js
+++ b/src/CqlProcessor.js
@@ -1,6 +1,6 @@
-import cql from 'cql-execution';
-import fhir from 'cql-exec-fhir';
-import fhirHelpersJson from './FHIRHelpers-4.0.1.json.js';
+import cql from "cql-execution";
+import fhir from "cql-exec-fhir";
+import fhirHelpersJson from "./FHIRHelpers-4.0.1.json.js";
 
 /**
  * Executes logical expression written in the Clinical Quality Language (CQL) against
@@ -14,15 +14,24 @@ export default class CqlProcessor {
    * @param {object} parameters - Key:value pairs of parameters for the CQL library
    * @param {object} elmJsonDependencies - Libraries referenced from within elmJson.
    */
-  constructor(elmJson, valueSetJson, parameters=null, elmJsonDependencies = {}) {
+  constructor(
+    elmJson,
+    valueSetJson,
+    parameters = null,
+    elmJsonDependencies = {}
+  ) {
     this.patientSource = fhir.PatientSource.FHIRv401();
-    this.repository  = new cql.Repository({
-      'FHIRHelpers': fhirHelpersJson,
-      ...elmJsonDependencies
+    this.repository = new cql.Repository({
+      FHIRHelpers: fhirHelpersJson,
+      ...elmJsonDependencies,
     });
     this.library = new cql.Library(elmJson, this.repository);
     this.codeService = new cql.CodeService(valueSetJson);
-    this.executor = new cql.Executor(this.library, this.codeService, parameters);
+    this.executor = new cql.Executor(
+      this.library,
+      this.codeService,
+      parameters
+    );
   }
 
   /**
@@ -32,9 +41,9 @@ export default class CqlProcessor {
   loadBundle(patientBundle) {
     this.patientSource.reset(); // necessary to avoid memory leaks
     this.patientSource.loadBundles([patientBundle]);
-    this.patientID = this.patientSource._bundles[0].entry.
-      filter(resrc => resrc.resource.resourceType == 'Patient').
-      map(resrc => resrc.resource.id);
+    this.patientID = this.patientSource._bundles[0].entry
+      .filter((resrc) => resrc.resource.resourceType == "Patient")
+      .map((resrc) => resrc.resource.id);
   }
 
   /**
@@ -46,9 +55,27 @@ export default class CqlProcessor {
   async evaluateExpression(expr) {
     // Only try to evaluate an expression if we have a patient bundle loaded.
     if (this.patientSource._bundles && this.patientSource._bundles.length > 0) {
-      let results = await this.executor.exec_expression(expr, this.patientSource);
-      this.patientSource._index = 0; // HACK: rewind the patient source
-      return results.patientResults[this.patientID][expr];
+      let results;
+      if (expr == "__evaluate_library__") {
+        results = await this.executor.exec(this.patientSource);
+        return results.patientResults[this.patientID];
+      } else {
+        results = await this.executor.exec_expression(
+          expr,
+          this.patientSource
+        );
+        this.patientSource._index = 0; // HACK: rewind the patient source
+        return results.patientResults[this.patientID][expr];
+      }
     } else return null;
+  }
+
+  /**
+   * Evaluate an expression from the CQL library represented by elmJson against
+   * the patient bundle.
+   * @returns {object} results - The results from executing the expression
+   */
+  async evaluateLibrary() {
+    return this.evaluateExpression("__evaluate_library__");
   }
 }

--- a/src/cql.worker.js
+++ b/src/cql.worker.js
@@ -23,10 +23,16 @@ onmessage = async function(rx) {
 
   // For efficiency, first check if this is an expression message, since that is
   // the type called most often.
-  if ((expression = rx.data.expression) != null) {
-    let tx;
+
+   if ((expression = rx.data.expression) != null) {
+
+    let tx,result;
     if (processor.patientSource._bundles.length > 0) {
-      let result = await processor.evaluateExpression(expression);
+      if(expression == '__evaluate_library__'){
+        result = await processor.evaluateLibrary();
+      }else{
+        result = await processor.evaluateExpression(expression);
+      }
       tx = {
         expression: expression,
         result: result


### PR DESCRIPTION
This PR adds the ability to evaluate an entire CQL library and return the results back to the caller. It does this by utilizing the existing processing framework in place and uses a specific evaluate_library expression to evaluate the library.